### PR TITLE
Community Shaders compatibility fix

### DIFF
--- a/skyrim-platform/src/platform_se/skyrim_platform/main.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/main.cpp
@@ -23,6 +23,8 @@
 
 extern CallNativeApi::NativeCallRequirements g_nativeCallRequirements;
 
+static std::function<void()> g_installPresentHook;
+
 void GetTextsToDraw(TextToDrawCallback callback)
 {
   switch (TextApi::GetTextsVisibility()) {
@@ -178,6 +180,10 @@ DLLEXPORT bool SKSEAPI SKSEPlugin_Load_Impl(const SKSE::LoadInterface* skse)
     [](SKSE::MessagingInterface::Message* a_msg) {
       EventHandler::HandleSKSEMessage(a_msg);
       BrowserApiNirnLab::GetInstance().HandleSkseMessage(a_msg);
+      if (a_msg->type == SKSE::MessagingInterface::kDataLoaded) {
+        if (g_installPresentHook)
+          g_installPresentHook();
+      }
     });
 
   Hooks::Install();
@@ -552,13 +558,19 @@ public:
 
     renderSystem = std::make_shared<RenderSystemD3D11>(*overlayService);
 
-    auto manager = RE::BSRenderManager::GetSingleton();
-    if (!manager) {
-      logger::critical("Failed to retrieve BSRenderManager");
-    }
+    // NOTE: D3D11 is not yet initialized at BeginMain() time.
+    // The Present hook is installed later from kDataLoaded when D3D11 is ready.
+    auto rs = renderSystem;
+    g_installPresentHook = [rs]() {
+      auto manager = RE::BSRenderManager::GetSingleton();
+      if (!manager || !manager->swapChain)
+        return;
 
-    renderSystem->m_pSwapChain =
-      reinterpret_cast<IDXGISwapChain*>(manager->swapChain);
+      rs->m_pSwapChain =
+        reinterpret_cast<IDXGISwapChain*>(manager->swapChain);
+
+      CEFUtils::D3D11Hook::InstallOnSwapChain(rs->m_pSwapChain);
+    };
 
     return true;
   }

--- a/skyrim-platform/src/tilted/hooks/D3D11Hook.cpp
+++ b/skyrim-platform/src/tilted/hooks/D3D11Hook.cpp
@@ -3,61 +3,38 @@
 #include <d3d11.h>
 
 #include <FunctionHook.hpp>
-#include <mutex>
 
 using TDXGISwapChainPresent = HRESULT(STDMETHODCALLTYPE*)(IDXGISwapChain* This,
                                                           UINT SyncInterval,
                                                           UINT Flags);
 
-using TD3D11CreateDeviceAndSwapChain = HRESULT (*)(
-  IDXGIAdapter* pAdapter, D3D_DRIVER_TYPE DriverType, HMODULE Software,
-  UINT Flags, const D3D_FEATURE_LEVEL* pFeatureLevels, UINT FeatureLevels,
-  UINT SDKVersion, const DXGI_SWAP_CHAIN_DESC* pSwapChainDesc,
-  IDXGISwapChain** ppSwapChain, ID3D11Device** ppDevice,
-  D3D_FEATURE_LEVEL* pFeatureLevel, ID3D11DeviceContext** ppImmediateContext);
-
-TD3D11CreateDeviceAndSwapChain RealD3D11CreateDeviceAndSwapChain = nullptr;
 TDXGISwapChainPresent RealDXGISwapChainPresent = nullptr;
 
 namespace CEFUtils {
-HRESULT __stdcall HookDXGISwapChainPresent(IDXGISwapChain* This,
-                                           UINT SyncInterval, UINT Flags)
+
+static bool s_initialized = false;
+
+static void DoPresent(IDXGISwapChain* This)
 {
   auto& d3d11 = D3D11Hook::Get();
 
-  static std::once_flag s_initializer;
-  std::call_once(s_initializer, [&d3d11, This]() { d3d11.OnCreate(This); });
-
-  d3d11.OnPresent(This);
-
-  const auto result = RealDXGISwapChainPresent(This, SyncInterval, Flags);
-  if (result == DXGI_ERROR_DEVICE_REMOVED ||
-      result == DXGI_ERROR_DEVICE_RESET) {
-    d3d11.OnLost(This);
+  if (!s_initialized) {
+    s_initialized = true;
+    d3d11.OnCreate(This);
   }
 
-  return result;
+  d3d11.OnPresent(This);
 }
 
-HRESULT HookD3D11CreateDeviceAndSwapChain(
-  _In_opt_ IDXGIAdapter* pAdapter, D3D_DRIVER_TYPE DriverType,
-  HMODULE Software, UINT Flags,
-  _In_opt_ const D3D_FEATURE_LEVEL* pFeatureLevels, UINT FeatureLevels,
-  UINT SDKVersion, _In_opt_ const DXGI_SWAP_CHAIN_DESC* pSwapChainDesc,
-  _Out_opt_ IDXGISwapChain** ppSwapChain, _Out_opt_ ID3D11Device** ppDevice,
-  _Out_opt_ D3D_FEATURE_LEVEL* pFeatureLevel,
-  _Out_opt_ ID3D11DeviceContext** ppImmediateContext)
+HRESULT __stdcall HookDXGISwapChainPresent(IDXGISwapChain* This,
+                                           UINT SyncInterval, UINT Flags)
 {
-  const auto result = RealD3D11CreateDeviceAndSwapChain(
-    pAdapter, DriverType, Software, Flags, pFeatureLevels, FeatureLevels,
-    SDKVersion, pSwapChainDesc, ppSwapChain, ppDevice, pFeatureLevel,
-    ppImmediateContext);
+  try {
+    DoPresent(This);
+  } catch (...) {
+  }
 
-  if (RealDXGISwapChainPresent == nullptr && ppSwapChain)
-    RealDXGISwapChainPresent =
-      HookVTable(*ppSwapChain, 8, &HookDXGISwapChainPresent);
-
-  return result;
+  return RealDXGISwapChainPresent(This, SyncInterval, Flags);
 }
 
 D3D11Hook::D3D11Hook() noexcept
@@ -66,7 +43,17 @@ D3D11Hook::D3D11Hook() noexcept
 
 void D3D11Hook::Install() noexcept
 {
-  TP_HOOK_IAT(D3D11CreateDeviceAndSwapChain, "d3d11.dll");
+  // No-op. Use InstallOnSwapChain() after D3D11 initialization instead.
+  // IAT hooking D3D11CreateDeviceAndSwapChain conflicts with Community Shaders.
+}
+
+void D3D11Hook::InstallOnSwapChain(IDXGISwapChain* pSwapChain) noexcept
+{
+  if (!pSwapChain || RealDXGISwapChainPresent != nullptr)
+    return;
+
+  RealDXGISwapChainPresent =
+    HookVTable(pSwapChain, 8, &HookDXGISwapChainPresent);
 }
 
 D3D11Hook& D3D11Hook::Get() noexcept

--- a/skyrim-platform/src/tilted/hooks/D3D11Hook.hpp
+++ b/skyrim-platform/src/tilted/hooks/D3D11Hook.hpp
@@ -14,6 +14,7 @@ struct D3D11Hook
   Signal<void(IDXGISwapChain*)> OnLost;
 
   static void Install() noexcept;
+  static void InstallOnSwapChain(IDXGISwapChain* pSwapChain) noexcept;
   static D3D11Hook& Get() noexcept;
 
 private:

--- a/skyrim-platform/src/tilted/ui/DX11RenderHandler.cpp
+++ b/skyrim-platform/src/tilted/ui/DX11RenderHandler.cpp
@@ -8,6 +8,7 @@
 #include <OverlayClient.h>
 #include <cmrc/cmrc.hpp>
 #include <codecvt>
+#include <d3d11.h>
 #include <filesystem>
 #include <functional>
 #include <iostream>
@@ -118,11 +119,20 @@ void DX11RenderHandler::Reset()
 
 void DX11RenderHandler::Create()
 {
-  const auto hr = m_pRenderer->GetSwapChain()->GetDevice(
-    IID_ID3D11Device,
-    reinterpret_cast<void**>(m_pDevice.ReleaseAndGetAddressOf()));
+  // Get device via back buffer instead of swap chain's GetDevice.
+  // CS (Community Shaders) proxies the swap chain and its GetDevice
+  // returns E_NOINTERFACE. GetBuffer(0) returns the real back buffer
+  // from which we can obtain the actual device.
+  Microsoft::WRL::ComPtr<ID3D11Texture2D> pBackBuffer;
+  auto hr = m_pRenderer->GetSwapChain()->GetBuffer(
+    0, IID_PPV_ARGS(pBackBuffer.GetAddressOf()));
 
   if (FAILED(hr))
+    return;
+
+  pBackBuffer->GetDevice(m_pDevice.ReleaseAndGetAddressOf());
+
+  if (!m_pDevice)
     return;
 
   m_pDevice->GetImmediateContext(m_pImmediateContext.ReleaseAndGetAddressOf());


### PR DESCRIPTION
Install the rendering hook after the game's graphics are ready.

- Fixes compatibility issue with Community Shaders where you were not able to see floating texts (Those not rendered through NirnLab UI).
- Fixes edge case scenarios where you could get a black screen after selecting character and loading into the world.
- Potential fix for other mods that hooks into D3D11.

Tested live at Public-2, works fine.