### PR TITLE
Differentiate roll chat messages

### DIFF
--- a/skymp5-front/src/constructorComponents/chat/index.js
+++ b/skymp5-front/src/constructorComponents/chat/index.js
@@ -181,13 +181,15 @@ const Chat = (props) => {
 
   const getMessageSpans = (message) => {
     let isNonRp = message.category === 'plain';
+    let isRoll = message.category === 'roll';
     const result = message.text.map(({ text, color, opacity, type }, i) => {
+      isRoll = isRoll || type.includes('roll');
       if (i >= 1) {
         isNonRp = (type.includes('nonrp') && isNonRp);
       }
       return <span key={`${text}_${i}`} style={{ color: `${color}`, opacity: opacity }} className={`${type.join(' ')}`}>{text}</span>;
     });
-    return [result, isNonRp];
+    return [result, isNonRp, isRoll ? 'roll' : ''];
   };
 
   const getList = () => {
@@ -195,7 +197,7 @@ const Chat = (props) => {
       const result = getMessageSpans(msg);
       return (
         <div
-          className={`msg ${result[1] ? 'nonrp' : ''}`}
+          className={`msg ${result[1] ? 'nonrp' : ''} ${result[2]}`}
           key={`msg-${index}`}
           style={{ marginLeft: '10px', opacity: msg.opacity }}
         >

--- a/skymp5-front/src/constructorComponents/chat/styles.scss
+++ b/skymp5-front/src/constructorComponents/chat/styles.scss
@@ -83,6 +83,12 @@
         &.action {
           color: #c37bdd;
         }
+        &.roll {
+          color: #c37bdd;
+          span {
+            color: #c37bdd !important;
+          }
+        }
         &.admin {
           color: #ce3131;
         }


### PR DESCRIPTION
This adds frontend support for rendering chat messages tagged as `roll` with a distinct purple color.

The goal is to make trusted `/roll` output visually different from player-written action text, so messages like `/me <roll text>` are easier to distinguish from real roll results.

Changes:
- Detects chat messages with `category: "roll"` or span type `roll`.
- Adds a `roll` row class in the chat UI.
- Applies a purple color to trusted roll messages.
- Leaves existing `/me`, OOC, GM, admin, and other chat colors unchanged.

Note: I noticed the public repo references `RollCommand`, but the actual command implementation does not appear to be included here. If Keizaal handles `/roll` in private gamemode/server code, that code would also need to tag real roll output as `roll` for this styling to apply.

Testing:
- Ran `git diff --check` locally.
- Full frontend build was not run because frontend dependencies were not installed in my local environment.